### PR TITLE
Fixing error where git resource errors without an empty dir.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -6,6 +6,10 @@
 package "git-core"
 package "python-setuptools"
 
+directory "#{node[:s3cmd][:install_prefix_root]}/share/s3cmd" do
+  action :create
+end
+
 git "#{node[:s3cmd][:install_prefix_root]}/share/s3cmd" do
   repository "git://github.com/s3tools/s3cmd.git"
   reference node[:s3cmd][:version]


### PR DESCRIPTION
Hey!

Thanks for the cookbook.  I'm not sure what the problem is, maybe related to new 'git' resource changes, but I needed to create the empty dir to clone into.  Cheers,

-Nick
