### PR TITLE
Remove executable for the world flag

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -37,6 +37,8 @@ node[:s3cmd][:users].each do |user|
   template "s3cfg" do
       path "#{home}/.s3cfg"
       source "s3cfg.erb"
-      mode 0655
+      user "#{user}"
+      group "#{user}"
+      mode 0600
   end
 end


### PR DESCRIPTION
The config file doesnt have to be executable for the world and even not readable by anybody except the user it self
