### PR TITLE
parameterizing bucket_location for wider non US use

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -11,6 +11,7 @@ All node attributes are set under the :s3cmd namespace.
 * :users - array of usernames for whom a .s3cfg will be created in their home directory; defaults to [:root]
 * :aws_access_key_id - AWS access key for S3
 * :aws_secret_access_key - AWS secret access key for S3
+* :bucket_location - AWS bucket location for S3; defaults to "US"
 
 = USAGE:
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,9 @@
 # list of users that will have the s3cmd configuration 
 default[:s3cmd][:users] = [:root]
 
+# Bucket Location
+default[:s3cmd][:bucket_location] = "US"
+
 # S3 credentials
 default[:s3cmd][:aws_access_key_id] = ""
 default[:s3cmd][:aws_secret_access_key] = ""

--- a/templates/default/s3cfg.erb
+++ b/templates/default/s3cfg.erb
@@ -1,7 +1,7 @@
 [default]
 access_key = <%= node[:s3cmd][:aws_access_key_id] %>
 acl_public = False
-bucket_location = US
+bucket_location = <%= node[:s3cmd][:bucket_location] %>
 cloudfront_host = cloudfront.amazonaws.com
 cloudfront_resource = /2008-06-30/distribution
 default_mime_type = binary/octet-stream


### PR DESCRIPTION
takes out the hard reference to bucket_location "US" replacing it with an attribute - more friendly to non US users to override :)
