### PR TITLE
Added installation of python-dateutil package

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -5,6 +5,8 @@
 
 package "git-core"
 package "python-setuptools"
+# Newer versions of s3cmd require "dateutil"
+package "python-dateutil"
 
 directory "#{node[:s3cmd][:install_prefix_root]}/share/s3cmd" do
   action :create


### PR DESCRIPTION
This is a requirement for the newer versions of s3cmd.

https://github.com/s3tools/s3cmd/blob/master/setup.py#L78
